### PR TITLE
Updating wording for url.py changes

### DIFF
--- a/book-3-levelup/chapters/LU_AUTHENTICATION.md
+++ b/book-3-levelup/chapters/LU_AUTHENTICATION.md
@@ -101,7 +101,7 @@ from .auth import check_user, register_user
 
 The last step is to establish some URL routes that any client application can use to register and check a gamer to use the API.
 
-Completely replace the contents of the following file with the code below.
+Update the contents of the following file with the code below.
 
 > #### `levelup-server/levelup/urls.py`
 


### PR DESCRIPTION
If I recall correctly, authentication used to come before the API routes. And, because it is been moved, the new wording of the line in this PR instructs students to delete all API routes added in previous chapters. So the purpose of this PR is to change that text so that it no longer says to delete everything in the file, but rather to add the new contents to the file.